### PR TITLE
Remove redundant square roots

### DIFF
--- a/src/getSensor.cpp
+++ b/src/getSensor.cpp
@@ -18,7 +18,7 @@ float getPopulationDensityAlongAxis(Coord loc, Dir dir)
     // An empty neighborhood results in a sensor value exactly midrange; below
     // midrange if the population density is greatest in the reverse direction,
     // above midrange if density is greatest in forward direction.
-
+    assert(dir != Compass::CENTER);
     double sum = 0.0;
     Coord dirVec = dir.asNormalizedCoord();
     double len = std::sqrt(dirVec.x*dirVec.x + dirVec.y*dirVec.y);
@@ -33,19 +33,7 @@ float getPopulationDensityAlongAxis(Coord loc, Dir dir)
         }
     };
 
-    auto g = [&](Coord tloc) { //Special case for dir = 4
-        if (tloc != loc && grid.isOccupiedAt(tloc)) {
-            Coord offset = tloc - loc;
-            double contrib = 1/std::sqrt((double)offset.x * offset.x + (double)offset.y * offset.y);
-            sum += contrib;
-        }
-    };
-
-    if (dir.asInt()!=4){
-        visitNeighborhood(loc, p.populationSensorRadius, f);
-    } else {
-        visitNeighborhood(loc, p.populationSensorRadius, g);
-    }
+    visitNeighborhood(loc, p.populationSensorRadius, f);
 
     double maxSumMag = 6.0 * p.populationSensorRadius;
     assert(sum >= -maxSumMag && sum <= maxSumMag);
@@ -125,7 +113,7 @@ float getSignalDensityAlongAxis(unsigned layerNum, Coord loc, Dir dir)
     // about 2*radius*SIGNAL_MAX (?). We don't adjust for being close to a border,
     // so signal densities along borders and in corners are commonly sparser than
     // away from borders.
-
+    assert(dir != Compass::CENTER);
     double sum = 0.0;
     Coord dirVec = dir.asNormalizedCoord();
     double len = std::sqrt(dirVec.x*dirVec.x + dirVec.y*dirVec.y);
@@ -140,19 +128,7 @@ float getSignalDensityAlongAxis(unsigned layerNum, Coord loc, Dir dir)
         }
     };
 
-    auto g = [&](Coord tloc) { //Special case for dir = 4
-        if (tloc != loc && grid.isOccupiedAt(tloc)) {
-            Coord offset = tloc - loc;
-            double contrib = signals.getMagnitude(layerNum, loc)/std::sqrt((double)offset.x * offset.x + (double)offset.y * offset.y);
-            sum += contrib;
-        }
-    };
-
-    if (dir.asInt()!=4){
-        visitNeighborhood(loc, p.populationSensorRadius, f);
-    } else {
-        visitNeighborhood(loc, p.populationSensorRadius, g);
-    }
+    visitNeighborhood(loc, p.populationSensorRadius, f);
 
     double maxSumMag = 6.0 * p.signalSensorRadius * SIGNAL_MAX;
     assert(sum >= -maxSumMag && sum <= maxSumMag);

--- a/src/getSensor.cpp
+++ b/src/getSensor.cpp
@@ -20,12 +20,15 @@ float getPopulationDensityAlongAxis(Coord loc, Dir dir)
     // above midrange if density is greatest in forward direction.
 
     double sum = 0.0;
+    Coord dirVec = dir.asNormalizedCoord();
+    double len = std::sqrt(dirVec.x*dirVec.x + dirVec.y*dirVec.y);
+    double dirVecX = dirVec.x/len;
+    double dirVecY = dirVec.y/len; //Unit vector components along dir
     auto f = [&](Coord tloc) {
         if (tloc != loc && grid.isOccupiedAt(tloc)) {
             Coord offset = tloc - loc;
-            double anglePosCos = offset.raySameness(dir);
-            double dist = std::sqrt((double)offset.x * offset.x + (double)offset.y * offset.y);
-            double contrib = (1.0 / dist) * anglePosCos;
+            double proj = (dirVecX*offset.x + dirVecY*offset.y); //Magnitude of projection along dir
+            double contrib = proj/(offset.x * offset.x + offset.y * offset.y);
             sum += contrib;
         }
     };
@@ -111,12 +114,15 @@ float getSignalDensityAlongAxis(unsigned layerNum, Coord loc, Dir dir)
     // away from borders.
 
     double sum = 0.0;
+    Coord dirVec = dir.asNormalizedCoord();
+    double len = std::sqrt(dirVec.x*dirVec.x + dirVec.y*dirVec.y);
+    double dirVecX = dirVec.x/len;
+    double dirVecY = dirVec.y/len; //Unit vector components along dir
     auto f = [&](Coord tloc) {
         if (tloc != loc) {
             Coord offset = tloc - loc;
-            double anglePosCos = offset.raySameness(dir);
-            double dist = std::sqrt((double)offset.x * offset.x + (double)offset.y * offset.y);
-            double contrib = (1.0 / dist) * anglePosCos * signals.getMagnitude(layerNum, loc);
+            double proj = (dirVecX*offset.x + dirVecY*offset.y); //Magnitude of projection along dir
+            double contrib = proj/(offset.x * offset.x + offset.y * offset.y) * signals.getMagnitude(layerNum, loc);
             sum += contrib;
         }
     };


### PR DESCRIPTION
These two functions both calculate `cos(t)/r`, where t is the angle between `offset` and `dir` and `r` is the length of `offset`. This method achieves that by calculating a unit vector in the direction of `dir`, which is then accessed by `f` without recalculating each call. The dot product of this vector with `offset` is then just `cos(t)*r`, since the other vector is of unit length. Finding `cos(t)/r` then just requires dividing by `r^2`.

On my machine, this reduces the time spend in these functions by around 40%, and this speeds up the entire program by around 25% (with video encoding disabled and other settings default), but obviously this is dependent on how often these signals are being used.

The output of this function is within 10^(-8) of the output of the original, with the difference coming largely from the fact that `raySameness` only works to float precision, whereas it seems intended for this function to work to double precision.

The comments mention that this function uses the "positive absolute cosine", which seems to imply that `|cos(t)|` should be being used instead. Doing that fails to reproduce the behaviour of the code being replaced so I've left it as is.