### PR TITLE
Allow the MOVE_LR action to go in the left.

### DIFF
--- a/src/executeActions.cpp
+++ b/src/executeActions.cpp
@@ -198,13 +198,8 @@ void executeActions(Indiv &indiv, std::array<float, Action::NUM_ACTIONS> &action
     }
     if (isEnabled(Action::MOVE_RL)) {
         level = actionLevels[Action::MOVE_RL];
-        if (level < 0.0) {
-            offset = indiv.lastMoveDir.rotate90DegCCW().asNormalizedCoord();
-        } else if (level > 0.0) {
-            offset = indiv.lastMoveDir.rotate90DegCW().asNormalizedCoord();
-        } else {
-            offset = { 0, 0 };
-        }
+        offset = indiv.lastMoveDir.rotate90DegCW().asNormalizedCoord();
+        level = 2.0f * (level - 0.5f);
         moveX += offset.x * level;
         moveY += offset.y * level;
     }

--- a/src/executeActions.cpp
+++ b/src/executeActions.cpp
@@ -199,7 +199,6 @@ void executeActions(Indiv &indiv, std::array<float, Action::NUM_ACTIONS> &action
     if (isEnabled(Action::MOVE_RL)) {
         level = actionLevels[Action::MOVE_RL];
         offset = indiv.lastMoveDir.rotate90DegCW().asNormalizedCoord();
-        level = 2.0f * (level - 0.5f);
         moveX += offset.x * level;
         moveY += offset.y * level;
     }


### PR DESCRIPTION
As written, when the level is less than zero, it goes left a negative amount. This is the same as going right with a positive amount. So, this action only goes to the right.

If the range of level is from -1.0f to 1.0f, then the code for MOVE_RIGHT is correct for this case. too For when it's less than zero, it goes right a negative amount.

But, if we limit the range of neurons between 0.0f and 1.0f, then how about setting 0.5f as moving forward, less than that is to the left, and more it to the right? The proposed fix is for this expectation.