### PR TITLE
fix bug in github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,4 +19,4 @@ jobs:
           docker build -t biosim4 .
 
       - name: compile
-        run: docker run --rm -ti -v `pwd`:/app --name biosim biosim4 make
+        run: docker run --rm -v `pwd`:/app --name biosim biosim4 make

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,8 @@ name: docker
 on:
   push:
     branches: '*'
+  pull_request:
+    branches: '*'
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,4 +21,8 @@ jobs:
           docker build -t biosim4 .
 
       - name: compile
-        run: docker run --rm -v `pwd`:/app --name biosim biosim4 make
+        run: |
+          docker run --rm \
+            -v `pwd`:/app \
+            --user `id -u`:`id -g` \
+            --name biosim biosim4 make


### PR DESCRIPTION
now that it's actually working, i can test it and fix it =)

this checks that any changes made to the code base do not ruin the compilation of the program by ensuring that `make` still completes.

the problem was that github action runs in an environment where the `-ti` flag makes no sense, it was sloppy on my part to forget omitting them (just a copy/paste thing). It's the difference between what you want to run on your machine to make it useful to work with VS what you want in CI to perform checks.