### PR TITLE
Optimise basicTypes.cpp

### DIFF
--- a/src/basicTypes.cpp
+++ b/src/basicTypes.cpp
@@ -8,21 +8,17 @@ namespace BS {
 // eight steps per full rotation. Positive values are clockwise; negative
 // values are counterclockwise. E.g., rotate(4) returns a direction 90
 // degrees to the right.
-#define SW BS::Compass::SW
-#define W BS::Compass::W
-#define NW BS::Compass::NW
-#define N BS::Compass::N
-#define NE BS::Compass::NE
-#define E BS::Compass::E
-#define SE BS::Compass::SE
-#define S BS::Compass::S
-#define CENTER BS::Compass::CENTER
+constexpr Compass NW = BS::Compass::NW; constexpr Compass N = BS::Compass::N;
+constexpr Compass NE = BS::Compass::NE; constexpr Compass E = BS::Compass::E;
+constexpr Compass SE = BS::Compass::SE; constexpr Compass S = BS::Compass::S;
+constexpr Compass SW = BS::Compass::SW; constexpr Compass W = BS::Compass::W;
+constexpr Compass C = BS::Compass::CENTER;
+
 const Dir rotations[72] = {SW, W, NW, N, NE, E, SE, S,
                             S, SW, W, NW, N, NE, E, SE,
                             SE, S, SW, W, NW, N, NE, E,
                             W, NW, N, NE, E, SE, S, SW,
-                            CENTER, CENTER, CENTER, CENTER,
-                            CENTER, CENTER, CENTER, CENTER,
+                            C, C, C, C, C, C, C, C,
                             E, SE, S, SW, W, NW, N, NE,
                             NW, N, NE, E, SE, S, SW, W,
                             N, NE, E, SE, S, SW, W, NW,
@@ -32,7 +28,7 @@ const Coord NormalisedCoords[9] = {Coord(-1,-1), Coord(0,-1), Coord(1,-1),
                                     Coord(-1,0), Coord(0,0), Coord(1,0),
                                     Coord(-1,1), Coord(0,1), Coord(1,1)};
 
-const Dir conversion[16] {S, CENTER, SW, N, SE, E, N,
+const Dir conversion[16] {S, C, SW, N, SE, E, N,
                             N, N, N, W, NW, N, NE, N, N};
 
 Dir Dir::rotate(int n) const

--- a/src/basicTypes.cpp
+++ b/src/basicTypes.cpp
@@ -138,7 +138,7 @@ Coord Polar::asCoord() const
 
 float Coord::raySameness(Coord other) const
 {
-    int64_t mag = (x * x + y * y) * (other.x * other.x + other.y * other.y);
+    int64_t mag = ((int64_t)x * x + y * y) * (other.x * other.x + other.y * other.y);
     if (mag == 0) {
         return 1.0; // anything is "same" as zero vector
     }

--- a/src/basicTypes.cpp
+++ b/src/basicTypes.cpp
@@ -8,7 +8,15 @@ namespace BS {
 // eight steps per full rotation. Positive values are clockwise; negative
 // values are counterclockwise. E.g., rotate(4) returns a direction 90
 // degrees to the right.
-
+#define SW BS::Compass::SW
+#define W BS::Compass::W
+#define NW BS::Compass::NW
+#define N BS::Compass::N
+#define NE BS::Compass::NE
+#define E BS::Compass::E
+#define SE BS::Compass::SE
+#define S BS::Compass::S
+#define CENTER BS::Compass::CENTER
 const Dir rotations[72] = {SW, W, NW, N, NE, E, SE, S,
                             S, SW, W, NW, N, NE, E, SE,
                             SE, S, SW, W, NW, N, NE, E,


### PR DESCRIPTION
I've cleaned up most functions in basicTypes.cpp, a few were worth improving for performance reasons but I thought I'd clean up the others whilst I was at it. Most of them weren't performance bottlenecks, though their replacements are at least as performant and as accurate under reasonable constraints.

Rotations are now done through a lookup table with index `dir*8 + n%7`. This removes the need for looping or checks of any kind, and rotations outside of [0,7] are now handled too. This is around 30-50% faster depending on the situation, which cuts 2-3% off the running time of the program.

Converting a `Dir` to a `Coord` is now done by lookup too, this is around 50% faster, cutting an incredible 0.5% off the running time. 

`asDir` has been overhauled to remove the `atan2` call and floating point arithmetic. The new method uses the idea that there are 4 lines which bisect the angles between coordinate directions, and by checking which side of those lines a point is, it can be determined which direction it is closest to. These lines are like `y = (1+sqrt(2))*x` which would be messy to work with, instead rotate the whole system 22.5 degrees so the lines become `y=x`, `y=-x`, `y=0` and `x=0`. This method is around 20x faster than the original, and accurate for all possible `Coord` inputs (tested exhaustively). I had to switch the original implementation's floats for doubles for testing as there were some points that it classified incorrectly, but after that the two methods agreed.

`asCoord` has also been overhauled to remove the trigonometric functions and the floating point arithmetic. It is around twice as fast, and the output matches with the original for all 9 coordinate directions, and for values of `mag` in [-46341,46341], since this is the largest `mag` can be and still be in bounds.