### PR TITLE
Add params for deterministic RNG

### DIFF
--- a/biosim4.ini
+++ b/biosim4.ini
@@ -1,15 +1,15 @@
 # biosim4.ini
-# biosim4.ini is the default config file for the simluator.
+# biosim4.ini is the default config file for the simulator.
 # The config filename is determined in simulator() in simulator.cpp.
 # The config file is parsed by class ParamManager, see params.cpp and params.h.
-# Although not foolproof, the config file can be modifed during a simulation
+# Although not foolproof, the config file can be modified during a simulation
 # run and the param manager will make any new params available to the simulator
 # after the end of the current simulator step or after the end of the current
 # generation.
 
 # numThreads must be 1 or greater. Best value is less than or equal to
 # the number of CPU cores.
-numThreads = 10
+numThreads = 4
 
 # sizeX, sizeY define the size of the 2D world. Minimum size is 16,16.
 # Maximum size is 32767, 32767.
@@ -24,15 +24,15 @@ stepsPerGeneration = 300
 
 # The simulator will stop when the generation number == maxGenerations.
 # Range 1..INT_MAX
-maxGenerations = 2000000
+maxGenerations = 200000
 
 # genomeInitialLengthMin and genomeInitialLengthMax should be set to
 # the same value. (For future use, the max length might be larger to
 # allow mutations that lengthen the genome.) Range 1..INT_MAX and
 # must be no larger than genomeMaxLength. The range of genomeMaxLength
 # is genomeInitialLengthMax..INT_MAX.
-genomeInitialLengthMin = 48
-genomeInitialLengthMax = 48
+genomeInitialLengthMin = 24
+genomeInitialLengthMax = 24
 genomeMaxLength = 300
 
 # maxNumberNeurons is the maximum number of internal neurons that may
@@ -81,7 +81,7 @@ populationSensorRadius = 2.5
 # longProbeDistance is the default distance that the long-probe sensors
 # are able to see. Applies to long-probe population sensor and long-probe
 # signal (pheromone) sensor. Range 1..INT_MAX.
-longProbeDistance = 24
+longProbeDistance = 16
 
 # shortProbeBarrierDistance is the distance that the short-probe sensor
 # can see. Range 1..INT_MAX.
@@ -160,7 +160,7 @@ genomeComparisonMethod = 1
 # When genomic statistics are printed (see genomeAnalysisStride), the number
 # of genomes sampled from the population and printed to stdout is determined
 # by displaySampleGenomes. Range 0 to population size.
-displaySampleGenomes = 10
+displaySampleGenomes = 5
 
 # challenge determines the selection criterion for reproduction. This is
 # typically always under active development. See survival-criteria.cpp for
@@ -184,7 +184,7 @@ displaySampleGenomes = 10
 # 15 = pairs
 # 16 = contact location sequence
 # 17 = altruism, circle + NE corner
-challenge = 17
+challenge = 6
 
 # The simulator supports a feature called "barriers." Barriers are locations
 # in the simulated 2D world where agents may not occupy. The value of
@@ -205,4 +205,15 @@ barrierType = 0
 # disable.
 replaceBarrierType = 0
 replaceBarrierTypeGenerationNumber = -1
+
+# If true, then the random number generator (RNG) will be seeded by the value
+# in RNGSeed, causing each thread to receive a deterministic sequence from
+# the RNG. If false, the RNG will be randomly seeded and program output will
+# be non-deterministic.
+deterministic = false
+
+# If deterministic is true, the random number generator will be seeded with
+# this value. If deterministic is false, this value is ignored. Legal values
+# are integers 0 to 4294967295.
+RNGSeed = 12345678
 

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -13,7 +13,7 @@
 
 // To add a new parameter:
 //    1. Add a member to struct Params in params.h.
-//    2. Add a member and its default value to privParams in ParamManager::setDefault()
+//    2. Add a member and its default value to privParams in ParamManager::setDefaults()
 //          in params.cpp.
 //    3. Add an else clause to ParamManager::ingestParameter() in params.cpp.
 //    4. Add a line to the user's parameter file (default name biosim4.ini)
@@ -24,45 +24,47 @@ void ParamManager::setDefaults()
 {
     privParams.sizeX = 128;
     privParams.sizeY = 128;
-    privParams.challenge = 0;
+    privParams.challenge = 6;
 
-    privParams.genomeInitialLengthMin = 16;
-    privParams.genomeInitialLengthMax = 16;
-    privParams.genomeMaxLength = 20;
+    privParams.genomeInitialLengthMin = 24;
+    privParams.genomeInitialLengthMax = 24;
+    privParams.genomeMaxLength = 300;
     privParams.logDir = "./logs/";
     privParams.imageDir = "./images/";
-    privParams.population = 100;
-    privParams.stepsPerGeneration = 100;
-    privParams.maxGenerations = 100;
+    privParams.population = 3000;
+    privParams.stepsPerGeneration = 300;
+    privParams.maxGenerations = 200000;
     privParams.barrierType = 0;
     privParams.replaceBarrierType = 0;
     privParams.replaceBarrierTypeGenerationNumber = (uint32_t)-1;
-    privParams.numThreads = 1;
+    privParams.numThreads = 4;
     privParams.signalLayers = 1;
-    privParams.maxNumberNeurons = privParams.genomeMaxLength / 2;
-    privParams.pointMutationRate = 0.0001;
-    privParams.geneInsertionDeletionRate = 0.0001;
-    privParams.deletionRatio = 0.7;
+    privParams.maxNumberNeurons = 5;
+    privParams.pointMutationRate = 0.001;
+    privParams.geneInsertionDeletionRate = 0.0;
+    privParams.deletionRatio = 0.5;
     privParams.killEnable = false;
     privParams.sexualReproduction = true;
     privParams.chooseParentsByFitness = true;
-    privParams.populationSensorRadius = 2.0;
-    privParams.signalSensorRadius = 1;
+    privParams.populationSensorRadius = 2.5;
+    privParams.signalSensorRadius = 2.0;
     privParams.responsiveness = 0.5;
     privParams.responsivenessCurveKFactor = 2;
     privParams.longProbeDistance = 16;
-    privParams.shortProbeBarrierDistance = 3;
+    privParams.shortProbeBarrierDistance = 4;
     privParams.valenceSaturationMag = 0.5;
     privParams.saveVideo = true;
-    privParams.videoStride = 1;
-    privParams.videoSaveFirstFrames = 0;
-    privParams.displayScale = 1;
-    privParams.agentSize = 2;
-    privParams.genomeAnalysisStride = 1;
-    privParams.displaySampleGenomes = 0;
+    privParams.videoStride = 25;
+    privParams.videoSaveFirstFrames = 2;
+    privParams.displayScale = 8;
+    privParams.agentSize = 4;
+    privParams.genomeAnalysisStride = privParams.videoStride;
+    privParams.displaySampleGenomes = 5;
     privParams.genomeComparisonMethod = 1;
-    privParams.updateGraphLog = false;
-    privParams.updateGraphLogStride = 16;
+    privParams.updateGraphLog = true;
+    privParams.updateGraphLogStride = privParams.videoStride;
+    privParams.deterministic = false;
+    privParams.RNGSeed = 12345678;
     privParams.graphLogUpdateCommand = "/usr/bin/gnuplot --persist ./tools/graphlog.gp";
 }
 
@@ -258,6 +260,12 @@ void ParamManager::ingestParameter(std::string name, std::string val)
         }
         else if (name == "updategraphlogstride" && val == "videoStride") {
             privParams.updateGraphLogStride = privParams.videoStride; break;
+        }
+        else if (name == "deterministic" && isBool) {
+            privParams.deterministic = bVal; break;
+        }
+        else if (name == "rngseed" && isUint) {
+            privParams.RNGSeed = uVal; break;
         }
         else {
             std::cout << "Invalid param: " << name << " = " << val << std::endl;

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -305,4 +305,15 @@ void ParamManager::updateFromConfigFile()
     }
 }
 
+
+// Check parameter ranges, reasonableness, coherency, whatever. This is
+// typically called only once after the parameters are first read.
+void ParamManager::checkParameters()
+{
+    if (privParams.deterministic && privParams.numThreads != 1) {
+        std::cerr << "Warning: When deterministic is true, you probably want to set numThreads = 1." << std::endl;
+    }
+}
+
+
 } // end namespace BS

--- a/src/params.h
+++ b/src/params.h
@@ -75,6 +75,7 @@ public:
     void setDefaults();
     void registerConfigFile(const char *filename);
     void updateFromConfigFile();
+    void checkParameters();
 private:
     Params privParams;
     std::string configFilename;

--- a/src/params.h
+++ b/src/params.h
@@ -56,6 +56,8 @@ struct Params {
     unsigned barrierType; // >= 0
     unsigned replaceBarrierType; // >= 0
     unsigned replaceBarrierTypeGenerationNumber; // >= 0
+    bool deterministic;
+    unsigned RNGSeed; // >= 0
 
     // These must not change after initialization
     uint16_t sizeX; // 2..0x10000

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -1,58 +1,79 @@
 // random.cpp
-// Provides a random number generator for the main thread
-// and child threads
+
+// This file provides a random number generator (RNG) for the main thread
+// and child threads. There is a global RNG instance named randomUint which
+// can be duplicated so that each thread gets a private copy. The global
+// RNG must be initialized after program startup by calling its initialize()
+// member function, typically at the top of simulator() in simulator.cpp
+// after the parameters have been read. The parameters named "deterministic"
+// and "RNGSeed" determine whether to initialize the RNG with a
+// user-defined deterministic seed or with a random seed.
 
 #include <cassert>
 #include <cmath>
 #include <random>
 #include <chrono>
 #include <climits>
-#include "random.h"
-#include "omp.h"
+#include "simulator.h"
+
 
 namespace BS {
 
 
-// Default is determinstic
-RandomUintGenerator::RandomUintGenerator(bool deterministic)
+RandomUintGenerator::RandomUintGenerator()
+    : initialized(false)
 {
-    if (deterministic) {
-        // for Marsaglia
-        rngx = 123456789;
-        rngy = 362436000;
-        rngz = 521288629;
-        rngc = 7654321;
+}
 
-        // for Jenkins:
-        a = 0xf1ea5eed, b = c = d = 123456789;
+
+// If parameter p.deterministic is true, we'll initialize the RNG with
+// the seed specified in parameter p.RNGSeed, otherwise we'll initialize
+// the RNG with a random seed. This initializes both the Marsaglia and
+// the Jenkins algorithms. The member function operator() determines
+// which algorithm is actually used.
+void RandomUintGenerator::initialize()
+{
+    if (p.deterministic) {
+        // Initialize Marsaglia. Overflow wrap-around is ok. We just want
+        // the four parameters to be unrelated:
+        rngx = p.RNGSeed + 123456789;
+        rngy = p.RNGSeed + 362436000;
+        rngz = p.RNGSeed + 521288629;
+        rngc = p.RNGSeed + 7654321;
+
+        // Initialize Jenkins:
+        a = 0xf1ea5eed;
+        b = c = d = p.RNGSeed;
     } else {
-        randomize();
+        // Non-deterministic
+        // Get a random seed from the built-in generator
+        std::mt19937 generator(time(0));  // mt19937 is a standard mersenne_twister_engine
+
+        // Initialize Marsaglia, but don't let any of the values be zero:
+        do { rngx = generator(); } while (rngx == 0);
+        do { rngy = generator(); } while (rngy == 0);
+        do { rngz = generator(); } while (rngz == 0);
+        do { rngc = generator(); } while (rngc == 0);
+
+        // Initialize Jenkins, but don't let any of the values be zero:
+        a = 0xf1ea5eed;
+        do { b = c = d = generator(); } while (b == 0);
     }
+
+    initialized = true; // for debugging, remember that we initialized the RNG
 }
 
 
-void RandomUintGenerator::randomize()
-{
-    std::mt19937 generator(time(0));  // mt19937 is a standard mersenne_twister_engine
-
-    // for Marsaglia
-    do { rngx = generator(); } while (rngx == 0);
-    do { rngy = generator(); } while (rngy == 0);
-    do { rngz = generator(); } while (rngz == 0);
-    do { rngc = generator(); } while (rngc == 0);
-
-    // for Jenkins:
-    a = 0xf1ea5eed, b = c = d = generator();
-}
-
-
-// This algorithm is from http://www0.cs.ucl.ac.uk/staff/d.jones/GoodPracticeRNG.pdf
+// This returns a random 32-bit integer. Neither the Marsaglia nor the Jenkins
+// algorithms are of cryptographic quality, but we don't need that. We just need
+// randomness of shotgun quality. The Jenkins algorithm is the fastest.
+// The Marsaglia algorithm is from http://www0.cs.ucl.ac.uk/staff/d.jones/GoodPracticeRNG.pdf
 // where it is attributed to G. Marsaglia.
 //
 uint32_t RandomUintGenerator::operator()()
 {
     if (false) {
-        // Marsaglia
+        // Marsaglia algorithm
         uint64_t t, a = 698769069ULL;
         rngx = 69069 * rngx + 12345;
         rngy ^= (rngy << 13);
@@ -62,7 +83,7 @@ uint32_t RandomUintGenerator::operator()()
         rngc = (t >> 32);/* Also avoid setting z=c=0! */
         return rngx + rngy + (rngz = t);
     } else {
-        // Jenkins
+        // Jenkins algorithm
         #define rot32(x,k) (((x)<<(k))|((x)>>(32-(k))))
         uint32_t e = a - rot32(b, 27);
         a = b ^ rot32(c, 17);
@@ -74,11 +95,12 @@ uint32_t RandomUintGenerator::operator()()
 }
 
 
+// Returns an unsigned integer between min and max, inclusive.
 // Sure, there's a bias when using modulus operator where (max - min) is not
 // a power of two, but we don't care if we generate one value a little more
-// often than another. Our randomness does not have to be any better quality
-// than the randomness of a shotgun. We do care about speed, because this will
-// get called inside deeply nested inner loops.
+// often than another. Our randomness does not have to be high quality.
+// We do care about speed, because this will get called inside deeply nested
+// inner loops.
 //
 unsigned RandomUintGenerator::operator()(unsigned min, unsigned max)
 {
@@ -87,8 +109,9 @@ unsigned RandomUintGenerator::operator()(unsigned min, unsigned max)
 }
 
 
-// The globally accessible random number generator. Threads can be
-// given their own private copies of this.
+// This is the globally-accessible random number generator. Threads can
+// be given their own private copies of this. This object needs to be
+// initialized once before its first use by calling randomUint.initialize().
 RandomUintGenerator randomUint;
 
 } // end namespace BS

--- a/src/random.h
+++ b/src/random.h
@@ -15,22 +15,25 @@ extern float randomFloat11(); // -1.0..1.0
 
 class RandomUintGenerator{
 private:
-    // for Marsaglia
+    // for the Marsaglia algorithm
     uint32_t rngx;
     uint32_t rngy;
     uint32_t rngz;
     uint32_t rngc;
-    // for Jenkins
+    // for the Jenkins algorithm
     uint32_t a, b, c, d;
+    // for debugging, record whether the RNG got initialized properly
+    bool initialized;
 public:
-    RandomUintGenerator(bool deterministic = false);
+    RandomUintGenerator();
     RandomUintGenerator& operator=(const RandomUintGenerator &rhs) = default;
-    void randomize();
+    void initialize();
     uint32_t operator()();
     unsigned operator()(unsigned min, unsigned max);
 };
 
-// The globally accessible random number generator (not thread safe)
+// The globally accessible random number generator (not thread safe -- for
+// multi-threaded use, each thread must be given a private copy of this object)
 extern RandomUintGenerator randomUint;
 constexpr uint32_t RANDOM_UINT_MAX = 0xffffffff;
 

--- a/src/random.h
+++ b/src/random.h
@@ -8,12 +8,8 @@
 
 namespace BS {
 
-extern int randomInt(int min = 0, int max = INT_MAX);
-extern uint16_t randomU16(uint16_t min = 0, uint16_t max = (uint16_t)-1);
-extern float randomFloat01(); // 0.0..1.0
-extern float randomFloat11(); // -1.0..1.0
 
-class RandomUintGenerator{
+struct RandomUintGenerator{
 private:
     // for the Marsaglia algorithm
     uint32_t rngx;
@@ -22,19 +18,17 @@ private:
     uint32_t rngc;
     // for the Jenkins algorithm
     uint32_t a, b, c, d;
-    // for debugging, record whether the RNG got initialized properly
-    bool initialized;
 public:
-    RandomUintGenerator();
-    RandomUintGenerator& operator=(const RandomUintGenerator &rhs) = default;
-    void initialize();
+    void initialize(); // must be called to seed the RNG
     uint32_t operator()();
     unsigned operator()(unsigned min, unsigned max);
 };
 
-// The globally accessible random number generator (not thread safe -- for
-// multi-threaded use, each thread must be given a private copy of this object)
+// The globally-scoped random number generator. Declaring it
+// threadprivate causes each thread to instantiate a private instance.
 extern RandomUintGenerator randomUint;
+#pragma omp threadprivate(randomUint)
+
 constexpr uint32_t RANDOM_UINT_MAX = 0xffffffff;
 
 } // end namespace BS

--- a/src/simulator.cpp
+++ b/src/simulator.cpp
@@ -112,6 +112,7 @@ void simulator(int argc, char **argv)
     paramManager.setDefaults();
     paramManager.registerConfigFile(argc > 1 ? argv[1] : "biosim4.ini");
     paramManager.updateFromConfigFile();
+    paramManager.checkParameters(); // check and report any problems
 
     randomUint.initialize(); // seed the RNG for main-thread use
 

--- a/src/simulator.cpp
+++ b/src/simulator.cpp
@@ -31,7 +31,7 @@ Signals signals;  // A 2D array of pheromones that overlay the world grid
 Peeps peeps;      // The container of all the individuals in the population
 ImageWriter imageWriter; // This is for generating the movies
 
-// The paramManger maintains a private copy of the parameter values, and a copy
+// The paramManager maintains a private copy of the parameter values, and a copy
 // is available read-only through global variable p. Although this is not
 // foolproof, you should be able to modify the config file during a simulation
 // run and modify many of the parameters. See params.cpp and params.h for more info.
@@ -111,6 +111,9 @@ void simulator(int argc, char **argv)
     paramManager.setDefaults();
     paramManager.registerConfigFile(argc > 1 ? argv[1] : "biosim4.ini");
     paramManager.updateFromConfigFile();
+
+    // Initialize the global random number generator
+    randomUint.initialize();
 
     // Allocate container space. Once allocated, these container elements
     // will be reused in each new generation.


### PR DESCRIPTION
This branch implements new config parameters named "deterministic" and "RNGSeed" and modifies the way the global RNG object is initialized. Comments are welcome.

At the same time, I tweaked a few of the default parameters in biosim4.ini (e.g., 4 threads instead of 10). I also modified the internal defaults to be the same as those in biosim4.ini, so that even if biosim4.ini was an empty file, the simulator would still run with the same parameters.