### PR TITLE
minor tweak to Makefile so the project compiles properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ LD = g++
 WINDRES = windres
 
 INC = -I/usr/include/opencv4
-CFLAGS = -Wall -fexceptions
+CFLAGS = -Wall -fexceptions -fopenmp
 RESINC = 
 LIBDIR = 
 ARCH = `arch`
 LIB = /usr/lib/$(ARCH)-linux-gnu/libopencv_core.so /usr/lib/$(ARCH)-linux-gnu/libopencv_video.so /usr/lib/$(ARCH)-linux-gnu/libopencv_videoio.so
-LDFLAGS = -lX11 -lpthread
+LDFLAGS = -lX11 -lpthread  -lgomp
 
 INC_DEBUG = $(INC)
 CFLAGS_DEBUG = $(CFLAGS) -g -fopenmp


### PR DESCRIPTION
- Added -fopenmp to CFLAGS so that openMP pragma's are recognised and used
- Added -lgomp to LDFLAGS so openMP is linked properly

with these two minor changes everything makes properly on debian 11 inside my WSL2