### PR TITLE
Fix possible out of bounds array access

### DIFF
--- a/src/genome.cpp
+++ b/src/genome.cpp
@@ -385,7 +385,7 @@ Genome generateChildGenome(const std::vector<Genome> &parentGenomes)
 
     auto overlayWithSliceOf = [&](const Genome &gShorter) {
         uint16_t index0 = randomUint(0, gShorter.size() - 1);
-        uint16_t index1 = randomUint(0, gShorter.size());
+        uint16_t index1 = randomUint(0, gShorter.size() - 1);
         if (index0 > index1) {
             std::swap(index0, index1);
         }


### PR DESCRIPTION
When genome sizes are equal, there was a possible out of bounds array access here when the randomly generated number was equal to gShorter.size()