### PR TITLE
Energy cost system

### DIFF
--- a/biosim4.ini
+++ b/biosim4.ini
@@ -206,6 +206,25 @@ barrierType = 0
 replaceBarrierType = 0
 replaceBarrierTypeGenerationNumber = -1
 
+# Starting energy level of each individual.
+startingEnergy = 0
+
+# Energy cost deducted each simulator step per node 
+# (sensor, action, or inner neuron) of the neural network.
+neuralNetNodeEnergyCost = 0
+
+# Energy cost deducted each simulator step per connection of the neural network.
+neuralNetConnectionEnergyCost = 0
+
+# Energy cost per move action performed.
+moveActionEnergyCost = 0
+
+# Energy cost per kill action performed.
+killActionEnergyCost = 0
+
+# Energy cost per non-move action performed.
+otherActionEnergyCost = 0
+
 # If true, then the random number generator (RNG) will be seeded by the value
 # in RNGSeed, causing each thread to receive a deterministic sequence from
 # the RNG. If false, the RNG will be randomly seeded and program output will

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -164,6 +164,14 @@ void Indiv::printGenome() const
     std::cout << std::dec << std::endl;
 }
 
+// Prints neural net size statistics to stdout
+void Indiv::printNeuralNetStats() const
+{
+    std::cout << "Neural net node count: " << nnetNodesCount << std::endl;
+    std::cout << "Neural net connection count: " << nnet.connections.size() << std::endl;
+    std::cout << "Neural net energy cost: " << neuralNetEnergyCost() << std::endl;
+}
+
 
 ///*
 //Example format:
@@ -265,6 +273,25 @@ float averageGenomeLength()
     return sum / numberSamples;
 }
 
+std::pair<float, float> averageNeuralNetSize()
+{
+    unsigned totalNnetNodes = 0;
+    unsigned totalConnections = 0;
+    unsigned aliveIndividuals = 0;
+    for (size_t index = 1; index <= p.population; ++index) {
+        if (peeps[index].alive) {
+            totalNnetNodes += peeps[index].nnetNodesCount;
+            totalConnections += peeps[index].nnet.connections.size();
+            ++aliveIndividuals;
+        }
+    }
+
+    if (aliveIndividuals == 0) {
+        return { 0.0f, 0.0f };
+    }
+
+    return { float(totalNnetNodes) / aliveIndividuals, float(totalConnections) / aliveIndividuals };
+}
 
 // The epoch log contains one line per generation in a format that can be
 // fed to graphlog.gp to produce a chart of the simulation progress.
@@ -281,8 +308,17 @@ void appendEpochLog(unsigned generation, unsigned numberSurvivors, unsigned murd
     foutput.open(p.logDir + "/epoch-log.txt", std::ios::app);
 
     if (foutput.is_open()) {
-        foutput << generation << " " << numberSurvivors << " " << geneticDiversity()
-                << " " << averageGenomeLength() << " " << murderCount << std::endl;
+
+        const auto& [averageNnetNodeCount, averageConnectionCount] = averageNeuralNetSize();
+
+        foutput << generation << " " 
+                << numberSurvivors << " " 
+                << geneticDiversity() << " " 
+                << averageGenomeLength() << " " 
+                << murderCount << " " 
+                << averageNnetNodeCount << " "
+                << averageConnectionCount << " "
+                << std::endl;
     } else {
         assert(false);
     }
@@ -362,6 +398,7 @@ void displaySampleGenomes(unsigned count)
 
             //peeps[index].printNeuralNet();
             peeps[index].printIGraphEdgeList();
+            peeps[index].printNeuralNetStats();
 
 
             std::cout << "---------------------------" << std::endl;

--- a/src/executeActions.cpp
+++ b/src/executeActions.cpp
@@ -67,18 +67,44 @@ evaluated multithreadedly.
 
 void executeActions(Indiv &indiv, std::array<float, Action::NUM_ACTIONS> &actionLevels)
 {
+    auto actionEnergyCost = [](Action action) -> int
+    {
+        switch (action)
+        {
+        case MOVE_X:
+        case MOVE_Y:
+        case MOVE_FORWARD:
+        case MOVE_RL:
+        case MOVE_RANDOM:
+        case MOVE_EAST:
+        case MOVE_WEST:
+        case MOVE_NORTH:
+        case MOVE_SOUTH:
+        case MOVE_LEFT:
+        case MOVE_RIGHT:
+        case MOVE_REVERSE:
+            return p.moveActionEnergyCost;
+        case KILL_FORWARD:
+            return p.killActionEnergyCost;
+        default:
+            return p.otherActionEnergyCost;
+        }
+    };
+
     // Only a subset of all possible actions might be enabled (i.e., compiled in).
-    // This returns true if the specified action is enabled. See sensors-actions.h
-    // for how to enable sensors and actions during compilation.
-    auto isEnabled = [](enum Action action){ return (int)action < (int)Action::NUM_ACTIONS; };
+    // See sensors-actions.h for how to enable sensors and actions during compilation.
+    // This returns true if the specified action is enabled and enough energy is available to
+    // perform it
+    auto isAvailable = [&indiv, &actionEnergyCost](enum Action action){ return (int)action < (int)Action::NUM_ACTIONS && indiv.energy >= actionEnergyCost(action); };
 
     // Responsiveness action - convert neuron action level from arbitrary float range
     // to the range 0.0..1.0. If this action neuron is enabled but not driven, will
     // default to mid-level 0.5.
-    if (isEnabled(Action::SET_RESPONSIVENESS)) {
+    if (isAvailable(Action::SET_RESPONSIVENESS)) {
         float level = actionLevels[Action::SET_RESPONSIVENESS]; // default 0.0
         level = (std::tanh(level) + 1.0) / 2.0; // convert to 0.0..1.0
         indiv.responsiveness = level;
+        indiv.energy -= actionEnergyCost(Action::SET_RESPONSIVENESS);
     }
 
     // For the rest of the action outputs, we'll apply an adjusted responsiveness
@@ -88,23 +114,25 @@ void executeActions(Indiv &indiv, std::array<float, Action::NUM_ACTIONS> &action
     // Oscillator period action - convert action level nonlinearly to
     // 2..4*p.stepsPerGeneration. If this action neuron is enabled but not driven,
     // will default to 1.5 + e^(3.5) = a period of 34 simSteps.
-    if (isEnabled(Action::SET_OSCILLATOR_PERIOD)) {
+    if (isAvailable(Action::SET_OSCILLATOR_PERIOD)) {
         auto periodf = actionLevels[Action::SET_OSCILLATOR_PERIOD];
         float newPeriodf01 = (std::tanh(periodf) + 1.0) / 2.0; // convert to 0.0..1.0
         unsigned newPeriod = 1 + (int)(1.5 + std::exp(7.0 * newPeriodf01));
         assert(newPeriod >= 2 && newPeriod <= 2048);
         indiv.oscPeriod = newPeriod;
+        indiv.energy -= actionEnergyCost(Action::SET_OSCILLATOR_PERIOD);
     }
 
     // Set longProbeDistance - convert action level to 1..maxLongProbeDistance.
     // If this action neuron is enabled but not driven, will default to
     // mid-level period of 17 simSteps.
-    if (isEnabled(Action::SET_LONGPROBE_DIST)) {
+    if (isAvailable(Action::SET_LONGPROBE_DIST)) {
         constexpr unsigned maxLongProbeDistance = 32;
         float level = actionLevels[SET_LONGPROBE_DIST];
         level = (std::tanh(level) + 1.0) / 2.0; // convert to 0.0..1.0
         level = 1 + level * maxLongProbeDistance;
         indiv.longProbeDist = (unsigned)level;
+        indiv.energy -= actionEnergyCost(Action::SET_LONGPROBE_DIST);
     }
 
     // Emit signal0 - if this action value is below a threshold, nothing emitted.
@@ -112,20 +140,21 @@ void executeActions(Indiv &indiv, std::array<float, Action::NUM_ACTIONS> &action
     // signal (pheromone).
     // Pheromones may be emitted immediately (see signals.cpp). If this action neuron
     // is enabled but not driven, nothing will be emitted.
-    if (isEnabled(Action::EMIT_SIGNAL0)) {
+    if (isAvailable(Action::EMIT_SIGNAL0)) {
         constexpr float emitThreshold = 0.5;  // 0.0..1.0; 0.5 is midlevel
         float level = actionLevels[Action::EMIT_SIGNAL0];
         level = (std::tanh(level) + 1.0) / 2.0; // convert to 0.0..1.0
         level *= responsivenessAdjusted;
         if (level > emitThreshold && prob2bool(level)) {
             signals.increment(0, indiv.loc);
+            indiv.energy -= actionEnergyCost(Action::EMIT_SIGNAL0);
         }
     }
 
     // Kill forward -- if this action value is > threshold, value is converted to probability
     // of an attempted murder. Probabilities under the threshold are considered 0.0.
     // If this action neuron is enabled but not driven, the neighbors are safe.
-    if (isEnabled(Action::KILL_FORWARD) && p.killEnable) {
+    if (isAvailable(Action::KILL_FORWARD) && p.killEnable) {
         constexpr float killThreshold = 0.5;  // 0.0..1.0; 0.5 is midlevel
         float level = actionLevels[Action::KILL_FORWARD];
         level = (std::tanh(level) + 1.0) / 2.0; // convert to 0.0..1.0
@@ -137,6 +166,7 @@ void executeActions(Indiv &indiv, std::array<float, Action::NUM_ACTIONS> &action
                 if (indiv2.alive) {
                     assert((indiv.loc - indiv2.loc).length() == 1);
                     peeps.queueForDeath(indiv2);
+                    indiv.energy -= actionEnergyCost(Action::KILL_FORWARD);
                 }
             }
         }
@@ -166,44 +196,44 @@ void executeActions(Indiv &indiv, std::array<float, Action::NUM_ACTIONS> &action
 
     // moveX,moveY will be the accumulators that will hold the sum of all the
     // urges to move along each axis. (+- floating values of arbitrary range)
-    float moveX = isEnabled(Action::MOVE_X) ? actionLevels[Action::MOVE_X] : 0.0;
-    float moveY = isEnabled(Action::MOVE_Y) ? actionLevels[Action::MOVE_Y] : 0.0;
+    float moveX = isAvailable(Action::MOVE_X) ? actionLevels[Action::MOVE_X] : 0.0;
+    float moveY = isAvailable(Action::MOVE_Y) ? actionLevels[Action::MOVE_Y] : 0.0;
 
-    if (isEnabled(Action::MOVE_EAST)) moveX += actionLevels[Action::MOVE_EAST];
-    if (isEnabled(Action::MOVE_WEST)) moveX -= actionLevels[Action::MOVE_WEST];
-    if (isEnabled(Action::MOVE_NORTH)) moveY += actionLevels[Action::MOVE_NORTH];
-    if (isEnabled(Action::MOVE_SOUTH)) moveY -= actionLevels[Action::MOVE_SOUTH];
+    if (isAvailable(Action::MOVE_EAST)) moveX += actionLevels[Action::MOVE_EAST];
+    if (isAvailable(Action::MOVE_WEST)) moveX -= actionLevels[Action::MOVE_WEST];
+    if (isAvailable(Action::MOVE_NORTH)) moveY += actionLevels[Action::MOVE_NORTH];
+    if (isAvailable(Action::MOVE_SOUTH)) moveY -= actionLevels[Action::MOVE_SOUTH];
 
-    if (isEnabled(Action::MOVE_FORWARD)) {
+    if (isAvailable(Action::MOVE_FORWARD)) {
         level = actionLevels[Action::MOVE_FORWARD];
         moveX += lastMoveOffset.x * level;
         moveY += lastMoveOffset.y * level;
     }
-    if (isEnabled(Action::MOVE_REVERSE)) {
+    if (isAvailable(Action::MOVE_REVERSE)) {
         level = actionLevels[Action::MOVE_REVERSE];
         moveX -= lastMoveOffset.x * level;
         moveY -= lastMoveOffset.y * level;
     }
-    if (isEnabled(Action::MOVE_LEFT)) {
+    if (isAvailable(Action::MOVE_LEFT)) {
         level = actionLevels[Action::MOVE_LEFT];
         offset = indiv.lastMoveDir.rotate90DegCCW().asNormalizedCoord();
         moveX += offset.x * level;
         moveY += offset.y * level;
     }
-    if (isEnabled(Action::MOVE_RIGHT)) {
+    if (isAvailable(Action::MOVE_RIGHT)) {
         level = actionLevels[Action::MOVE_RIGHT];
         offset = indiv.lastMoveDir.rotate90DegCW().asNormalizedCoord();
         moveX += offset.x * level;
         moveY += offset.y * level;
     }
-    if (isEnabled(Action::MOVE_RL)) {
+    if (isAvailable(Action::MOVE_RL)) {
         level = actionLevels[Action::MOVE_RL];
         offset = indiv.lastMoveDir.rotate90DegCW().asNormalizedCoord();
         moveX += offset.x * level;
         moveY += offset.y * level;
     }
 
-    if (isEnabled(Action::MOVE_RANDOM)) {
+    if (isAvailable(Action::MOVE_RANDOM)) {
         level = actionLevels[Action::MOVE_RANDOM];
         offset = Dir::random8().asNormalizedCoord();
         moveX += offset.x * level;
@@ -232,6 +262,7 @@ void executeActions(Indiv &indiv, std::array<float, Action::NUM_ACTIONS> &action
     Coord newLoc = indiv.loc + movementOffset;
     if (grid.isInBounds(newLoc) && grid.isEmptyAt(newLoc)) {
         peeps.queueForMove(indiv, newLoc);
+        indiv.energy -= p.moveActionEnergyCost;
     }
 }
 

--- a/src/indiv.cpp
+++ b/src/indiv.cpp
@@ -24,7 +24,30 @@ void Indiv::initialize(uint16_t index_, Coord loc_, const Genome &&genome_)
     longProbeDist = p.longProbeDistance;
     challengeBits = (unsigned)false; // will be set true when some task gets accomplished
     genome = std::move(genome_);
+    energy = p.startingEnergy;
     createWiringFromGenome();
+    calculateNeuralNetStats();
+}
+
+void Indiv::calculateNeuralNetStats()
+{
+    // Determine unique neural network nodes:
+    using NeuronId = std::pair<uint16_t, uint16_t>;
+    std::vector<NeuronId> neuronIds;
+    for (auto const& conn : nnet.connections) {
+        neuronIds.push_back({ conn.sourceNum, conn.sourceType });
+        neuronIds.push_back({ conn.sinkNum, conn.sinkType });
+    }
+    std::sort(neuronIds.begin(), neuronIds.end());
+    auto uniqueEnd = std::unique(neuronIds.begin(), neuronIds.end());
+    
+    // Store unique neural network node count:
+    nnetNodesCount = uniqueEnd - neuronIds.begin(); 
+}
+
+unsigned Indiv::neuralNetEnergyCost() const
+{
+    return nnetNodesCount * p.neuralNetNodeEnergyCost + nnet.connections.size() * p.neuralNetConnectionEnergyCost;
 }
 
 } // end namespace BS

--- a/src/indiv.h
+++ b/src/indiv.h
@@ -21,18 +21,23 @@ struct Indiv {
     unsigned age;
     Genome genome;
     NeuralNet nnet;   // derived from .genome
+    int nnetNodesCount; // number of unique nodes in the indivs neural net
     float responsiveness;  // 0.0..1.0 (0 is like asleep)
     unsigned oscPeriod; // 2..4*p.stepsPerGeneration (TBD, see executeActions())
     unsigned longProbeDist; // distance for long forward probe for obstructions
     Dir lastMoveDir;  // direction of last movement
     unsigned challengeBits; // modified when the indiv accomplishes some task
+    int energy;
     std::array<float, Action::NUM_ACTIONS> feedForward(unsigned simStep); // reads sensors, returns actions
     float getSensor(Sensor, unsigned simStep) const;
     void initialize(uint16_t index, Coord loc, const Genome &&genome);
     void createWiringFromGenome(); // creates .nnet member from .genome member
+    void calculateNeuralNetStats();
+    unsigned neuralNetEnergyCost() const; // total energy "consumed" by the indivs neural net nodes and connections per step
     void printNeuralNet() const;
     void printIGraphEdgeList() const;
     void printGenome() const;
+    void printNeuralNetStats() const;
 };
 
 } // end namespace BS

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -66,6 +66,12 @@ void ParamManager::setDefaults()
     privParams.deterministic = false;
     privParams.RNGSeed = 12345678;
     privParams.graphLogUpdateCommand = "/usr/bin/gnuplot --persist ./tools/graphlog.gp";
+    privParams.startingEnergy = 0;
+    privParams.neuralNetNodeEnergyCost = 0;
+    privParams.neuralNetConnectionEnergyCost = 0;
+    privParams.moveActionEnergyCost = 0;
+    privParams.killActionEnergyCost = 0;
+    privParams.otherActionEnergyCost = 0;
 }
 
 
@@ -266,6 +272,24 @@ void ParamManager::ingestParameter(std::string name, std::string val)
         }
         else if (name == "rngseed" && isUint) {
             privParams.RNGSeed = uVal; break;
+        }
+        else if (name == "startingenergy" && isUint) {
+            privParams.startingEnergy = uVal; break;
+        }
+        else if (name == "neuralnetnodeenergycost" && isUint) {
+            privParams.neuralNetNodeEnergyCost = uVal; break;
+        }
+        else if (name == "neuralnetconnectionenergycost" && isUint) {
+            privParams.neuralNetConnectionEnergyCost = uVal; break;
+        }
+        else if (name == "moveactionenergycost" && isUint) {
+            privParams.moveActionEnergyCost = uVal; break;
+        }
+        else if (name == "killactionenergycost" && isUint) {
+            privParams.killActionEnergyCost = uVal; break;
+        }
+        else if (name == "otheractionenergycost" && isUint) {
+            privParams.otherActionEnergyCost = uVal; break;
         }
         else {
             std::cout << "Invalid param: " << name << " = " << val << std::endl;

--- a/src/params.h
+++ b/src/params.h
@@ -58,6 +58,12 @@ struct Params {
     unsigned replaceBarrierTypeGenerationNumber; // >= 0
     bool deterministic;
     unsigned RNGSeed; // >= 0
+    unsigned startingEnergy;
+    unsigned neuralNetNodeEnergyCost;
+    unsigned neuralNetConnectionEnergyCost;
+    unsigned moveActionEnergyCost;
+    unsigned killActionEnergyCost;
+    unsigned otherActionEnergyCost;
 
     // These must not change after initialization
     uint16_t sizeX; // 2..0x10000

--- a/src/simulator.cpp
+++ b/src/simulator.cpp
@@ -67,8 +67,13 @@ The other important variables are:
 void simStepOneIndiv(Indiv &indiv, unsigned simStep)
 {
     ++indiv.age; // for this implementation, tracks simStep
-    auto actionLevels = indiv.feedForward(simStep);
-    executeActions(indiv, actionLevels);
+    const int neuralNetEnergyCost = indiv.neuralNetEnergyCost();
+    if (indiv.energy >= neuralNetEnergyCost)
+    {
+        indiv.energy -= neuralNetEnergyCost;
+        auto actionLevels = indiv.feedForward(simStep);
+        executeActions(indiv, actionLevels);
+    }
 }
 
 


### PR DESCRIPTION
Added a system that enables assigning an energy cost to performed actions, neural net nodes, and connections, which are then deducted from a starting energy pool. This enables adding various interesting evolutionary pressures, such as tradeoff between "brain size" and movement, or between "violent" and "pacifist" approaches.

Cost of actions is divided into three categories: movement actions, kill action, and others. Could be extended to more categories, or even separate setting for each action, but that seemed excessive.

I was unsure if individuals that run out of energy should die, or just be paralyzed because they are unable to perform any actions or run their neural net. Right now it's the latter, since it makes observing the energy consumption easier in the videos. Maybe it could be a separate parameter - feedback welcome.

I also included some reporting around neural net size and energy consumption, to enable graphing changes in "brain size". These parts could be easily left out of the PR if they are not a good fit for upstream.

Further ideas that can be built on top of this: 
- energy sensory neuron so that decisions can be made based on available energy
- some kind of energy source (food) - would enable simulations where agents are competing for resources (other than space)