### PR TITLE
Remove X11 library dependency from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ RESINC =
 LIBDIR = 
 ARCH = `arch`
 LIB = /usr/lib/$(ARCH)-linux-gnu/libopencv_core.so /usr/lib/$(ARCH)-linux-gnu/libopencv_video.so /usr/lib/$(ARCH)-linux-gnu/libopencv_videoio.so
-LDFLAGS = -lX11 -lpthread  -lgomp
+LDFLAGS = -lpthread  -lgomp
 
 INC_DEBUG = $(INC)
 CFLAGS_DEBUG = $(CFLAGS) -g -fopenmp

--- a/src/imageWriter.cpp
+++ b/src/imageWriter.cpp
@@ -10,6 +10,7 @@
 #include "simulator.h"
 #include "imageWriter.h"
 #define cimg_use_opencv 1
+#define cimg_display 0
 #include "CImg.h"
 
 namespace BS {


### PR DESCRIPTION
This is a small change that removes -lX11 from the linker flags in the Makefile, thanks to the discovery by @fvbakel (see #34). Tested locally with Makefile in Ubuntu 20.04.