### PR TITLE
Generalized syntax for specifying an automatic parameter value change

### DIFF
--- a/biosim4.ini
+++ b/biosim4.ini
@@ -6,6 +6,12 @@
 # run and the param manager will make any new params available to the simulator
 # after the end of the current simulator step or after the end of the current
 # generation.
+# Parameter values can also be changed automatically based on the current generation
+# number of the simulation using the syntax (see barrierType param for example): 
+# <parameterName>@<generationNumber> = <newValue>
+# Instances of the same parameter have to be ascending by generation number to work
+# correctly, e.g. barrierType@100 must be later in the file than barrierType@50, 
+# which in turn must come after barrierType.
 
 # numThreads must be 1 or greater. Best value is less than or equal to
 # the number of CPU cores.
@@ -199,12 +205,10 @@ challenge = 6
 # 6 = sequence of spots
 barrierType = 0
 
-# The barrier type will automatically change from barrierType to
-# replaceBarrierType at the generation specified by
-# replaceBarrierTypeGenerationNumber. Range 0..INT_MAX, or set to -1 to
-# disable.
-replaceBarrierType = 0
-replaceBarrierTypeGenerationNumber = -1
+# This is an example of an automatic parameter change based on the generation.
+# If uncommented, the barrier type will automatically change to the new value
+# when the simulation reaches the the generation specified after the @ delimiter.
+# barrierType@500 = 5
 
 # If true, then the random number generator (RNG) will be seeded by the value
 # in RNGSeed, causing each thread to receive a deterministic sequence from

--- a/src/endOfGeneration.cpp
+++ b/src/endOfGeneration.cpp
@@ -19,8 +19,8 @@ void endOfGeneration(unsigned generation)
         if (p.saveVideo &&
                 ((generation % p.videoStride) == 0
                  || generation <= p.videoSaveFirstFrames
-                 || (generation >= p.replaceBarrierTypeGenerationNumber
-                     && generation <= p.replaceBarrierTypeGenerationNumber + p.videoSaveFirstFrames))) {
+                 || (generation >= p.parameterChangeGenerationNumber
+                     && generation <= p.parameterChangeGenerationNumber + p.videoSaveFirstFrames))) {
             imageWriter.saveGenerationVideo(generation);
         }
     }

--- a/src/endOfSimStep.cpp
+++ b/src/endOfSimStep.cpp
@@ -81,8 +81,8 @@ void endOfSimStep(unsigned simStep, unsigned generation)
     if (p.saveVideo &&
                 ((generation % p.videoStride) == 0
                  || generation <= p.videoSaveFirstFrames
-                 || (generation >= p.replaceBarrierTypeGenerationNumber
-                     && generation <= p.replaceBarrierTypeGenerationNumber + p.videoSaveFirstFrames))) {
+                 || (generation >= p.parameterChangeGenerationNumber
+                     && generation <= p.parameterChangeGenerationNumber + p.videoSaveFirstFrames))) {
         if (!imageWriter.saveVideoFrameSync(simStep, generation)) {
             std::cout << "imageWriter busy" << std::endl;
         }

--- a/src/params.h
+++ b/src/params.h
@@ -54,8 +54,6 @@ struct Params {
     unsigned updateGraphLogStride; // > 0
     unsigned challenge;
     unsigned barrierType; // >= 0
-    unsigned replaceBarrierType; // >= 0
-    unsigned replaceBarrierTypeGenerationNumber; // >= 0
     bool deterministic;
     unsigned RNGSeed; // >= 0
 
@@ -67,6 +65,9 @@ struct Params {
     std::string logDir;
     std::string imageDir;
     std::string graphLogUpdateCommand;
+
+    // These are updated automatically and not set via the parameter file
+    unsigned parameterChangeGenerationNumber; // the most recent generation number that an automatic parameter change occured at
 };
 
 class ParamManager {
@@ -74,7 +75,7 @@ public:
     const Params &getParamRef() const { return privParams; } // for public read-only access
     void setDefaults();
     void registerConfigFile(const char *filename);
-    void updateFromConfigFile();
+    void updateFromConfigFile(unsigned generationNumber);
     void checkParameters();
 private:
     Params privParams;

--- a/src/simulator.cpp
+++ b/src/simulator.cpp
@@ -111,7 +111,7 @@ void simulator(int argc, char **argv)
     // Todo: remove the hardcoded parameter filename.
     paramManager.setDefaults();
     paramManager.registerConfigFile(argc > 1 ? argv[1] : "biosim4.ini");
-    paramManager.updateFromConfigFile();
+    paramManager.updateFromConfigFile(0);
     paramManager.checkParameters(); // check and report any problems
 
     randomUint.initialize(); // seed the RNG for main-thread use
@@ -166,7 +166,7 @@ void simulator(int argc, char **argv)
             #pragma omp single
             {
                 endOfGeneration(generation);
-                paramManager.updateFromConfigFile();
+                paramManager.updateFromConfigFile(generation + 1);
                 unsigned numberSurvivors = spawnNewGeneration(generation, murderCount);
                 if (numberSurvivors > 0 && (generation % p.genomeAnalysisStride == 0)) {
                     displaySampleGenomes(p.displaySampleGenomes);

--- a/src/spawnNewGeneration.cpp
+++ b/src/spawnNewGeneration.cpp
@@ -19,8 +19,7 @@ void initializeGeneration0()
 {
     // The grid has already been allocated, just clear and reuse it
     grid.zeroFill();
-    grid.createBarrier(p.replaceBarrierTypeGenerationNumber == 0
-                       ? p.replaceBarrierType : p.barrierType);
+    grid.createBarrier(p.barrierType);
 
     // The signal layers have already been allocated, so just reuse them
     signals.zeroFill();
@@ -45,8 +44,7 @@ void initializeNewGeneration(const std::vector<Genome> &parentGenomes, unsigned 
     // The grid, signals, and peeps containers have already been allocated, just
     // clear them if needed and reuse the elements
     grid.zeroFill();
-    grid.createBarrier(generation >= p.replaceBarrierTypeGenerationNumber
-                       ? p.replaceBarrierType : p.barrierType);
+    grid.createBarrier(p.barrierType);
     signals.zeroFill();
 
     // Spawn the population. This overwrites all the elements of peeps[]


### PR DESCRIPTION
Inspired by the replaceBarrierType and replaceBarrierTypeGenerationNumber parameters, I wanted to have the option to change any runtime changable parameter automatically at a given generation number. Building on the automatic ini file reloading system, I came up with a generalized syntax for this without the need to add extra parameters: if you specify an existing parameter in the ini file and append "@123" to the parameter name, the new value will supersede the original value after generation 123. You can specify any number of value changes for the same parameter like this (e.g. make the value change at generation 100, 200, 400, etc.), the only limitation is that the generation specifiers (the "@<num> part) have to be in ascending order (higher generation numbers after lower) - this limitation could be removed but that would complicate the currently very simple implementation a bit.

I removed the original replaceBarrierType and replaceBarrierTypeGenerationNumber parameters since their function can be easily replicated via the new syntax.