### PR TITLE
Fix bug in deferred death and movement queues

### DIFF
--- a/src/endOfSimStep.cpp
+++ b/src/endOfSimStep.cpp
@@ -32,11 +32,13 @@ void endOfSimStep(unsigned simStep, unsigned generation)
 
         for (uint16_t index = 1; index <= p.population; ++index) { // index 0 is reserved
             Indiv &indiv = peeps[index];
-            int16_t distanceFromRadioactiveWall = std::abs(indiv.loc.x - radioactiveX);
-            if (distanceFromRadioactiveWall < p.sizeX / 2) {
-                float chanceOfDeath = 1.0 / distanceFromRadioactiveWall;
-                if (randomUint() / (float)RANDOM_UINT_MAX < chanceOfDeath) {
-                    peeps.queueForDeath(indiv);
+            if (indiv.alive) {
+                int16_t distanceFromRadioactiveWall = std::abs(indiv.loc.x - radioactiveX);
+                if (distanceFromRadioactiveWall < p.sizeX / 2) {
+                    float chanceOfDeath = 1.0 / distanceFromRadioactiveWall;
+                    if (randomUint() / (float)RANDOM_UINT_MAX < chanceOfDeath) {
+                        peeps.queueForDeath(indiv);
+                    }
                 }
             }
         }

--- a/src/executeActions.cpp
+++ b/src/executeActions.cpp
@@ -134,10 +134,8 @@ void executeActions(Indiv &indiv, std::array<float, Action::NUM_ACTIONS> &action
             Coord otherLoc = indiv.loc + indiv.lastMoveDir;
             if (grid.isInBounds(otherLoc) && grid.isOccupiedAt(otherLoc)) {
                 Indiv &indiv2 = peeps.getIndiv(otherLoc);
-                if (indiv2.alive) {
-                    assert((indiv.loc - indiv2.loc).length() == 1);
-                    peeps.queueForDeath(indiv2);
-                }
+                assert((indiv.loc - indiv2.loc).length() == 1);
+                peeps.queueForDeath(indiv2);
             }
         }
     }


### PR DESCRIPTION
This fixes #44 by preventing the radioactive challenge from placing an already-dead agent on the death queue, and preventing the movement of a dead agent while draining the movement queue.