### PR TITLE
Energy cost system (updated)

### DIFF
--- a/biosim4.ini
+++ b/biosim4.ini
@@ -216,6 +216,25 @@ barrierType = 0
 # when the simulation reaches the generation specified after the @ delimiter.
 # barrierType@500 = 5
 
+# Starting energy level of each individual.
+startingEnergy = 0
+
+# Energy cost deducted each simulator step per node 
+# (sensor, action, or inner neuron) of the neural network.
+neuralNetNodeEnergyCost = 0
+
+# Energy cost deducted each simulator step per connection of the neural network.
+neuralNetConnectionEnergyCost = 0
+
+# Energy cost per move action performed.
+moveActionEnergyCost = 0
+
+# Energy cost per kill action performed.
+killActionEnergyCost = 0
+
+# Energy cost per non-move action performed.
+otherActionEnergyCost = 0
+
 # If true, then the random number generator (RNG) will be seeded by the value
 # in RNGSeed, causing each thread to receive a deterministic sequence from
 # the RNG. If false, the RNG will be randomly seeded and program output will

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -164,6 +164,14 @@ void Indiv::printGenome() const
     std::cout << std::dec << std::endl;
 }
 
+// Prints neural net size statistics to stdout
+void Indiv::printNeuralNetStats() const
+{
+    std::cout << "Neural net node count: " << nnetNodesCount << std::endl;
+    std::cout << "Neural net connection count: " << nnet.connections.size() << std::endl;
+    std::cout << "Neural net energy cost: " << neuralNetEnergyCost() << std::endl;
+}
+
 
 ///*
 //Example format:
@@ -265,6 +273,25 @@ float averageGenomeLength()
     return sum / numberSamples;
 }
 
+std::pair<float, float> averageNeuralNetSize()
+{
+    unsigned totalNnetNodes = 0;
+    unsigned totalConnections = 0;
+    unsigned aliveIndividuals = 0;
+    for (size_t index = 1; index <= p.population; ++index) {
+        if (peeps[index].alive) {
+            totalNnetNodes += peeps[index].nnetNodesCount;
+            totalConnections += peeps[index].nnet.connections.size();
+            ++aliveIndividuals;
+        }
+    }
+
+    if (aliveIndividuals == 0) {
+        return { 0.0f, 0.0f };
+    }
+
+    return { float(totalNnetNodes) / aliveIndividuals, float(totalConnections) / aliveIndividuals };
+}
 
 // The epoch log contains one line per generation in a format that can be
 // fed to graphlog.gp to produce a chart of the simulation progress.
@@ -281,8 +308,17 @@ void appendEpochLog(unsigned generation, unsigned numberSurvivors, unsigned murd
     foutput.open(p.logDir + "/epoch-log.txt", std::ios::app);
 
     if (foutput.is_open()) {
-        foutput << generation << " " << numberSurvivors << " " << geneticDiversity()
-                << " " << averageGenomeLength() << " " << murderCount << std::endl;
+
+        const auto& [averageNnetNodeCount, averageConnectionCount] = averageNeuralNetSize();
+
+        foutput << generation << " " 
+                << numberSurvivors << " " 
+                << geneticDiversity() << " " 
+                << averageGenomeLength() << " " 
+                << murderCount << " " 
+                << averageNnetNodeCount << " "
+                << averageConnectionCount << " "
+                << std::endl;
     } else {
         assert(false);
     }
@@ -362,6 +398,7 @@ void displaySampleGenomes(unsigned count)
 
             //peeps[index].printNeuralNet();
             peeps[index].printIGraphEdgeList();
+            peeps[index].printNeuralNetStats();
 
 
             std::cout << "---------------------------" << std::endl;

--- a/src/indiv.cpp
+++ b/src/indiv.cpp
@@ -24,7 +24,30 @@ void Indiv::initialize(uint16_t index_, Coord loc_, Genome &&genome_)
     longProbeDist = p.longProbeDistance;
     challengeBits = (unsigned)false; // will be set true when some task gets accomplished
     genome = std::move(genome_);
+    energy = p.startingEnergy;
     createWiringFromGenome();
+    calculateNeuralNetStats();
+}
+
+void Indiv::calculateNeuralNetStats()
+{
+    // Determine unique neural network nodes:
+    using NeuronId = std::pair<uint16_t, uint16_t>;
+    std::vector<NeuronId> neuronIds;
+    for (auto const& conn : nnet.connections) {
+        neuronIds.push_back({ conn.sourceNum, conn.sourceType });
+        neuronIds.push_back({ conn.sinkNum, conn.sinkType });
+    }
+    std::sort(neuronIds.begin(), neuronIds.end());
+    auto uniqueEnd = std::unique(neuronIds.begin(), neuronIds.end());
+    
+    // Store unique neural network node count:
+    nnetNodesCount = uniqueEnd - neuronIds.begin(); 
+}
+
+unsigned Indiv::neuralNetEnergyCost() const
+{
+    return nnetNodesCount * p.neuralNetNodeEnergyCost + nnet.connections.size() * p.neuralNetConnectionEnergyCost;
 }
 
 } // end namespace BS

--- a/src/indiv.h
+++ b/src/indiv.h
@@ -21,18 +21,23 @@ struct Indiv {
     unsigned age;
     Genome genome;
     NeuralNet nnet;   // derived from .genome
+    int nnetNodesCount; // number of unique nodes in the indivs neural net
     float responsiveness;  // 0.0..1.0 (0 is like asleep)
     unsigned oscPeriod; // 2..4*p.stepsPerGeneration (TBD, see executeActions())
     unsigned longProbeDist; // distance for long forward probe for obstructions
     Dir lastMoveDir;  // direction of last movement
     unsigned challengeBits; // modified when the indiv accomplishes some task
+    int energy;
     std::array<float, Action::NUM_ACTIONS> feedForward(unsigned simStep); // reads sensors, returns actions
     float getSensor(Sensor, unsigned simStep) const;
     void initialize(uint16_t index, Coord loc, Genome &&genome);
     void createWiringFromGenome(); // creates .nnet member from .genome member
+    void calculateNeuralNetStats();
+    unsigned neuralNetEnergyCost() const; // total energy "consumed" by the indivs neural net nodes and connections per step
     void printNeuralNet() const;
     void printIGraphEdgeList() const;
     void printGenome() const;
+    void printNeuralNetStats() const;
 };
 
 } // end namespace BS

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -65,6 +65,12 @@ void ParamManager::setDefaults()
     privParams.RNGSeed = 12345678;
     privParams.graphLogUpdateCommand = "/usr/bin/gnuplot --persist ./tools/graphlog.gp";
     privParams.parameterChangeGenerationNumber = 0;
+    privParams.startingEnergy = 0;
+    privParams.neuralNetNodeEnergyCost = 0;
+    privParams.neuralNetConnectionEnergyCost = 0;
+    privParams.moveActionEnergyCost = 0;
+    privParams.killActionEnergyCost = 0;
+    privParams.otherActionEnergyCost = 0;
 }
 
 
@@ -257,6 +263,24 @@ void ParamManager::ingestParameter(std::string name, std::string val)
         }
         else if (name == "rngseed" && isUint) {
             privParams.RNGSeed = uVal; break;
+        }
+        else if (name == "startingenergy" && isUint) {
+            privParams.startingEnergy = uVal; break;
+        }
+        else if (name == "neuralnetnodeenergycost" && isUint) {
+            privParams.neuralNetNodeEnergyCost = uVal; break;
+        }
+        else if (name == "neuralnetconnectionenergycost" && isUint) {
+            privParams.neuralNetConnectionEnergyCost = uVal; break;
+        }
+        else if (name == "moveactionenergycost" && isUint) {
+            privParams.moveActionEnergyCost = uVal; break;
+        }
+        else if (name == "killactionenergycost" && isUint) {
+            privParams.killActionEnergyCost = uVal; break;
+        }
+        else if (name == "otheractionenergycost" && isUint) {
+            privParams.otherActionEnergyCost = uVal; break;
         }
         else {
             std::cout << "Invalid param: " << name << " = " << val << std::endl;

--- a/src/params.h
+++ b/src/params.h
@@ -56,6 +56,12 @@ struct Params {
     unsigned barrierType; // >= 0
     bool deterministic;
     unsigned RNGSeed; // >= 0
+    unsigned startingEnergy;
+    unsigned neuralNetNodeEnergyCost;
+    unsigned neuralNetConnectionEnergyCost;
+    unsigned moveActionEnergyCost;
+    unsigned killActionEnergyCost;
+    unsigned otherActionEnergyCost;
 
     // These must not change after initialization
     uint16_t sizeX; // 2..0x10000

--- a/src/simulator.cpp
+++ b/src/simulator.cpp
@@ -67,8 +67,13 @@ The other important variables are:
 void simStepOneIndiv(Indiv &indiv, unsigned simStep)
 {
     ++indiv.age; // for this implementation, tracks simStep
-    auto actionLevels = indiv.feedForward(simStep);
-    executeActions(indiv, actionLevels);
+    const int neuralNetEnergyCost = indiv.neuralNetEnergyCost();
+    if (indiv.energy >= neuralNetEnergyCost)
+    {
+        indiv.energy -= neuralNetEnergyCost;
+        auto actionLevels = indiv.feedForward(simStep);
+        executeActions(indiv, actionLevels);
+    }
 }
 
 

--- a/src/simulator.cpp
+++ b/src/simulator.cpp
@@ -74,6 +74,10 @@ void simStepOneIndiv(Indiv &indiv, unsigned simStep)
         auto actionLevels = indiv.feedForward(simStep);
         executeActions(indiv, actionLevels);
     }
+    else
+    {
+        peeps.queueForDeath(indiv);
+    }
 }
 
 


### PR DESCRIPTION
Added a system that enables assigning an energy cost to performed actions, neural net nodes, and connections, which are then deducted from a starting energy pool. Individuals that run out of energy die. This enables adding various interesting evolutionary pressures, such as tradeoff between "brain size" and movement, or between "violent" and "pacifist" approaches.

Cost of actions is divided into three categories: movement actions, kill action, and others. Could be extended to more categories, or even separate setting for each action, but that seemed excessive.

I also included some reporting around neural net size and energy consumption, to enable graphing changes in "brain size". These parts could be easily left out of the PR if they are not a good fit for _upstream._

Further ideas that can be built on top of this:

energy sensory neuron so that decisions can be made based on available energy
some kind of energy source (food) - would enable simulations where agents are competing for resources (other than space)

_Note: this is an update of my original PR, I rebased the branch and deleted the old one, which is why the PR was closed. Sorry for the confusion. Compared to the original PR, indivs that run out of energy die - turns out this is a more useful behavior when building further functionality on top of this. It also makes the implementation a bit simpler._