### PR TITLE
ubuntu 20.04 cimg-dev upgrade instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,8 +297,13 @@ choices if you want to proceed with Ubuntu 20.04:
 * You can strip out the code that generates the movies and just run the simulator without the movies. Most of
 that graphics code is in imageWriter.cpp and imageWriter.h.
 
-* You can upgrade your CImg.h to version 2.8.4 or later by getting it from the appropriate Debian repository.
-Sorry I don't have the instructions at hand to do this.
+* You can upgrade your CImg.h to version 2.8.4 or later by installing the [Ubuntu 22.04 cimg-dev package](https://packages.ubuntu.com/jammy/cimg-dev), For example:
+```
+cd /tmp && \
+wget http://mirrors.kernel.org/ubuntu/pool/universe/c/cimg/cimg-dev_2.9.4+dfsg-3_all.deb -O cimg-dev_2.9.4+dfsg-3_all.deb && \
+sudo apt install ./cimg-dev_2.9.4+dfsg-3_all.deb && \
+rm cimg-dev_2.9.4+dfsg-3_all.deb;
+```
 
 * You could convert the CImg.h function calls to use OpenCV directly. Sorry I don't have a guide for how
 to do that.


### PR DESCRIPTION
as luck would have it, the Ubuntu 22.04 package is modern enough and compatible with Ubuntu 20.04 :) some warnings:
- there is no guarantee that the exact package cimg-dev_2.9.4+dfsg-3_all.deb will be retained after a new update comes along, thus it's possible that the url goes 404 at some point (circle of life?)
- there is no guarantee that newer versions of that package remains 20.04 compatible (but i do find it very likely that the opposite is true, 20.04 will most likely be compatible with cimg-dev_2.9.4+dfsg-3_all.deb for the lifetime of 20.04)
- installing it like this means that the exact package cimg-dev will no longer be part of the ubuntu security updates..