### PR TITLE
Updated Ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/ubuntu:impish-20211102
+FROM docker.io/ubuntu:latest
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -yqq \


### PR DESCRIPTION
ubuntu:impish-20211102 is no longer available, updated to ubuntu:latest to make it more robust in the future