### PR TITLE
Fix externally-managed-environment issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -yqq \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN pip install igraph
+RUN apt-get update && apt install -yqq python3-igraph
 
 RUN apt-get update && apt-get install -yqq \
 	cimg-dev \


### PR DESCRIPTION
When I try to build, I got this error

```
❯ docker build -t biosim4 .
[+] Building 0.4s (6/9)                                    docker:desktop-linux
 => [internal] load build definition from Dockerfile                       0.0s
 => => transferring dockerfile: 646B                                       0.0s
 => [internal] load metadata for docker.io/library/ubuntu:latest           0.0s
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 2B                                            0.0s
 => [1/6] FROM docker.io/library/ubuntu:latest                             0.0s
 => CACHED [2/6] RUN apt-get update && apt-get install -y  build-essentia  0.0s
 => ERROR [3/6] RUN pip install igraph                                     0.3s
------
 > [3/6] RUN pip install igraph:
0.306 error: externally-managed-environment
0.306
0.306 × This environment is externally managed
0.306 ╰─> To install Python packages system-wide, try apt install
0.306     python3-xyz, where xyz is the package you are trying to
0.306     install.
0.306
0.306     If you wish to install a non-Debian-packaged Python package,
0.306     create a virtual environment using python3 -m venv path/to/venv.
0.306     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
0.306     sure you have python3-full installed.
0.306
0.306     If you wish to install a non-Debian packaged Python application,
0.306     it may be easiest to use pipx install xyz, which will manage a
0.306     virtual environment for you. Make sure you have pipx installed.
0.306
0.306     See /usr/share/doc/python3.12/README.venv for more information.
0.306
0.306 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
0.306 hint: See PEP 668 for the detailed specification.
------
Dockerfile:11
--------------------
   9 |     	&& rm -rf /var/lib/apt/lists/*
  10 |
  11 | >>> RUN pip install igraph
  12 |
  13 |     RUN apt-get update && apt-get install -y \
--------------------
ERROR: failed to solve: process "/bin/sh -c pip install igraph" did not complete successfully: exit code: 1
```

So use the package manager to install igraph