### PR TITLE
Fix for `externally-managed-environment` error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -yqq \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN pip install igraph
+RUN apt-get update && apt-get install -yqq python3-igraph
 
 RUN apt-get update && apt-get install -yqq \
 	cimg-dev \


### PR DESCRIPTION
I was having this error:
```
[+] Building 75.8s (7/10)                                                                          docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                               0.2s
 => => transferring dockerfile: 591B                                                                               0.0s
 => [internal] load metadata for docker.io/library/ubuntu:latest                                                   1.3s
 => [auth] library/ubuntu:pull token for registry-1.docker.io                                                      0.0s
 => [internal] load .dockerignore                                                                                  0.1s
 => => transferring context: 2B                                                                                    0.0s
 => [1/6] FROM docker.io/library/ubuntu:latest@sha256:8a37d68f4f73ebf3d4efafbcf66379bf3728902a8038616808f04e34a9a  5.4s
 => => resolve docker.io/library/ubuntu:latest@sha256:8a37d68f4f73ebf3d4efafbcf66379bf3728902a8038616808f04e34a9a  0.0s
 => => sha256:8a37d68f4f73ebf3d4efafbcf66379bf3728902a8038616808f04e34a9ab63ee 1.34kB / 1.34kB                     0.0s
 => => sha256:d35dfc2fe3ef66bcc085ca00d3152b482e6cafb23cdda1864154caf3b19094ba 424B / 424B                         0.0s
 => => sha256:edbfe74c41f8a3501ce542e137cf28ea04dd03e6df8c9d66519b6ad761c2598a 2.30kB / 2.30kB                     0.0s
 => => sha256:31e907dcc94a592a57796786399eb004dcbba714389fa615f5efa05a91316356 29.71MB / 29.71MB                   2.0s
 => => extracting sha256:31e907dcc94a592a57796786399eb004dcbba714389fa615f5efa05a91316356                          3.0s
 => [2/6] RUN apt-get update && apt-get install -yqq  build-essential  dumb-init  python3-pip  && apt-get clean   68.0s
 => ERROR [3/6] RUN pip install igraph                                                                             0.7s
------
 > [3/6] RUN pip install igraph:
0.599 error: externally-managed-environment
0.599
0.599 × This environment is externally managed
0.599 ╰─> To install Python packages system-wide, try apt install
0.599     python3-xyz, where xyz is the package you are trying to
0.599     install.
0.599
0.599     If you wish to install a non-Debian-packaged Python package,
0.599     create a virtual environment using python3 -m venv path/to/venv.
0.599     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
0.599     sure you have python3-full installed.
0.599
0.599     If you wish to install a non-Debian packaged Python application,
0.599     it may be easiest to use pipx install xyz, which will manage a
0.599     virtual environment for you. Make sure you have pipx installed.
0.599
0.599     See /usr/share/doc/python3.12/README.venv for more information.
0.599
0.599 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
0.599 hint: See PEP 668 for the detailed specification.
------
Dockerfile:11
--------------------
   9 |          && rm -rf /var/lib/apt/lists/*
  10 |
  11 | >>> RUN pip install igraph
  12 |
  13 |     RUN apt-get update && apt-get install -yqq \
--------------------
ERROR: failed to solve: process "/bin/sh -c pip install igraph" did not complete successfully: exit code: 1
```