### PR TITLE
Fixes min-max bug

### DIFF
--- a/src/survival-criteria.cpp
+++ b/src/survival-criteria.cpp
@@ -51,8 +51,8 @@ std::pair<bool, float> passedSurvivalCriterion(const Indiv &indiv, unsigned chal
     // of neighbors defined by neighbors and radius, where neighbors includes self
     case CHALLENGE_STRING:
         {
-            unsigned minNeighbors = 22;
-            unsigned maxNeighbors = 2;
+            unsigned minNeighbors = 2;
+            unsigned maxNeighbors = 22;
             float radius = 1.5;
 
             if (grid.isBorder(indiv.loc)) {


### PR DESCRIPTION
I think this is a bug..

minNeighbors > maxNeighbors, so the test will always be false.

I also think that maxNeighbors should be much smaller, given the radius is only 1.5
